### PR TITLE
feat: implement port status checking and update favorite ports display

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
       "name": "localhost-dashboard",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
-        "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "lucide-react": "^0.544.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -138,8 +137,6 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.3.5", "", { "dependencies": { "@eslint/core": "^0.15.2", "levn": "^0.4.1" } }, "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w=="],
 
     "@fontsource-variable/inter": ["@fontsource-variable/inter@5.2.8", "", {}, "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ=="],
-
-    "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.2.8", "", {}, "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 

--- a/src/components/FavoritePorts.tsx
+++ b/src/components/FavoritePorts.tsx
@@ -18,8 +18,17 @@ const PortLink: React.FC<{ port: Port; onRemove: (portNumber: number) => void }>
     href={`http://localhost:${port.number}`}
     target="_blank"
     rel="noopener noreferrer"
-    className={`card text-white shadow-xl transform transition-transform hover:scale-105 group ${port.color}`}
+    className={`card text-white shadow-xl transform transition-transform hover:scale-105 group relative ${
+      port.color
+    } ${port.isActive ? 'tooltip tooltip-success' : ''}`}
+    data-tip={port.isActive ? 'This port is active' : ''}
   >
+    {port.isActive !== undefined && port.isActive && (
+      <span
+        title="This port is active"
+        className="status status-success status-lg absolute top-0 right-0"
+      ></span>
+    )}
     <div className="card-body p-4 flex-row items-center justify-between">
       <div>
         <h3 className="card-title text-2xl font-bold">{port.number}</h3>

--- a/src/hooks/usePortStatus.ts
+++ b/src/hooks/usePortStatus.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export interface PortStatus {
+  [port: number]: boolean;
+}
+
+interface UsePortStatusOptions {
+  interval?: number;
+  timeout?: number;
+  enabled?: boolean;
+}
+
+/**
+ * Hook personnalisé pour vérifier le statut des ports
+ * Vérifie si chaque port est actif via une requête HEAD HTTP
+ */
+export const usePortStatus = (ports: number[], options: UsePortStatusOptions = {}) => {
+  const {
+    interval = 30000, // 30 secondes
+    timeout = 3000, // 3 secondes
+    enabled = true,
+  } = options;
+
+  const [portStatus, setPortStatus] = useState<PortStatus>({});
+  const [isChecking, setIsChecking] = useState(false);
+  const [lastChecked, setLastChecked] = useState<Date | null>(null);
+
+  /**
+   * Vérifie si un port spécifique est actif
+   */
+  const checkPortStatus = useCallback(
+    async (port: number): Promise<boolean> => {
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+        const response = await fetch(`http://localhost:${port}`, {
+          method: 'HEAD',
+          signal: controller.signal,
+          mode: 'no-cors',
+        });
+
+        clearTimeout(timeoutId);
+
+        return true;
+      } catch (error) {
+        return false;
+      }
+    },
+    [timeout]
+  );
+
+  /**
+   * Vérifie le statut de tous les ports
+   */
+  const checkAllPorts = useCallback(async () => {
+    if (!enabled || ports.length === 0) return;
+
+    setIsChecking(true);
+    const newStatus: PortStatus = {};
+
+    const promises = ports.map(async (port) => {
+      const isActive = await checkPortStatus(port);
+      newStatus[port] = isActive;
+    });
+
+    await Promise.all(promises);
+
+    setPortStatus(newStatus);
+    setLastChecked(new Date());
+    setIsChecking(false);
+  }, [ports, enabled, checkPortStatus]);
+
+  /**
+   * Force une vérification immédiate
+   */
+  const forceCheck = useCallback(() => {
+    checkAllPorts();
+  }, [checkAllPorts]);
+
+  useEffect(() => {
+    if (enabled && ports.length > 0) {
+      checkAllPorts();
+    }
+  }, [ports, enabled, checkAllPorts]);
+
+  useEffect(() => {
+    if (!enabled || interval <= 0) return;
+
+    const intervalId = setInterval(checkAllPorts, interval);
+    return () => clearInterval(intervalId);
+  }, [checkAllPorts, interval, enabled]);
+
+  return {
+    portStatus,
+    isChecking,
+    lastChecked,
+    forceCheck,
+    checkPort: checkPortStatus,
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
-
 export interface Port {
   number: number;
   description: string;
   color: string;
+  isActive?: boolean;
 }
 
 export interface LocalSite {


### PR DESCRIPTION
This pull request introduces a new feature to display the active status of favorite ports in the UI by checking their availability via HTTP requests. The implementation includes a custom React hook for port status checking, updates to the port data structure, and UI enhancements to show active ports visually.

**Port status checking feature:**

* Added a custom hook `usePortStatus` in `src/hooks/usePortStatus.ts` to periodically check if each port is active using HTTP HEAD requests, with configurable interval and timeout options.
* Updated the `Port` type in `src/types.ts` to include an optional `isActive` property, allowing each port to store its status.

**Integration and UI updates:**

* In `src/App.tsx`, integrated `usePortStatus` to check the status of favorite ports and pass the enhanced port objects (with `isActive`) to the `FavoritePorts` component. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L1-R7) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R19-R43) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L160-R183)
* Enhanced the `FavoritePorts` component in `src/components/FavoritePorts.tsx` to visually indicate when a port is active, using tooltips and a status badge.